### PR TITLE
Hotfix for PHP 7.2

### DIFF
--- a/Idna.php
+++ b/Idna.php
@@ -788,6 +788,7 @@ class Idna
         foreach (self::$NP['replacemaps'] as $np_src => $np_target) {
             if ($np_target[0] != $input[0]) continue;
             if (count($np_target) != $inp_len) continue;
+            if (!is_array($np_target) || !($np_target instanceOf \Countable)) continue;
             $hit = false;
             foreach ($input as $k2 => $v2) {
                 if ($v2 == $np_target[$k2]) {


### PR DESCRIPTION
Would otherwise fail with:

`PHP Warning:  count(): Parameter must be an array or an object that implements Countable in ...vendor/novutec/domainparser/Idna.php on line 661`

see http://php.net/manual/en/migration72.incompatible.php: 

> An E_WARNING will now be emitted when attempting to count() non-countable types (this includes the sizeof() alias function).