### PR TITLE
Fix "Array offset access syntax with curly braces is deprecated" on PHP 7.4

### DIFF
--- a/Idna.php
+++ b/Idna.php
@@ -423,7 +423,7 @@ class Idna
         $delim_pos = strrpos($encoded, '-');
         if ($delim_pos > self::byteLength($this->_punycode_prefix)) {
             for ($k = self::byteLength($this->_punycode_prefix); $k < $delim_pos; ++$k) {
-                $decoded[] = ord($encoded{$k});
+                $decoded[] = ord($encoded[$k]);
             }
         }
         $deco_len = count($decoded);
@@ -437,7 +437,7 @@ class Idna
 
         for ($enco_idx = ($delim_pos) ? ($delim_pos + 1) : 0; $enco_idx < $enco_len; ++$deco_len) {
             for ($old_idx = $idx, $w = 1, $k = $this->_base; 1 ; $k += $this->_base) {
-                $digit = $this->_decode_digit($encoded{$enco_idx++});
+                $digit = $this->_decode_digit($encoded[$enco_idx++]);
                 $idx += $digit * $w;
                 $t = ($k <= $bias) ? $this->_tmin :
                         (($k >= $bias + $this->_tmax) ? $this->_tmax : ($k - $bias));
@@ -829,7 +829,7 @@ class Idna
         $mode = 'next';
         $test = 'none';
         for ($k = 0; $k < $inp_len; ++$k) {
-            $v = ord($input{$k}); // Extract byte from input string
+            $v = ord($input[$k]); // Extract byte from input string
             if ($v < 128) { // We found an ASCII char - put into stirng as is
                 $output[$out_len] = $v;
                 ++$out_len;
@@ -960,7 +960,7 @@ class Idna
                 $out_len++;
                 $output[$out_len] = 0;
             }
-            $output[$out_len] += ord($input{$i}) << (8 * (3 - ($i % 4) ) );
+            $output[$out_len] += ord($input[$i]) << (8 * (3 - ($i % 4) ) );
         }
         return $output;
     }


### PR DESCRIPTION
> PHP Deprecated:  Array and string offset access syntax with curly braces is deprecated in novutec/domainparser/Idna.php on line 426
PHP Deprecated:  Array and string offset access syntax with curly braces is deprecated in novutec/domainparser/Idna.php on line 440
PHP Deprecated:  Array and string offset access syntax with curly braces is deprecated in novutec/domainparser/Idna.php on line 832
PHP Deprecated:  Array and string offset access syntax with curly braces is deprecated in novutec/domainparser/Idna.php on line 963
