### PR TITLE
Fix exception management breaking change compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  phpunit:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        php-version: ['7.3', '7.4', '8.0']
+    name: 'PHPUnit - PHP/${{ matrix.php-version }} - OS/${{ matrix.os }}'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          coverage: xdebug
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-
+      - name: Install Dependencies
+        run: composer install --no-progress
+      - name: PHPUnit
+        run: vendor/bin/phpunit

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
 /vendor/
+.phpunit.result.cache
 composer.lock
 
 # User-specific stuff:

--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,17 @@
         "ext-mbstring": "*",
         "ext-pcre": "*"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^9.5"
+    },
     "autoload": {
         "psr-4": {
             "Novutec\\DomainParser\\": "src"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Novutec\\DomainParser\\Tests\\": "tests"
         }
     },
     "config": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+>
+    <testsuites>
+        <testsuite name="DomainParser">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <coverage>
+        <include>
+            <directory>src</directory>
+        </include>
+    </coverage>
+</phpunit>

--- a/src/AbstractException.php
+++ b/src/AbstractException.php
@@ -1,12 +1,12 @@
 <?php
 /**
  * Novutec Domain Tools.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,20 +20,39 @@
  */
 
 /**
- * @namespace Novutec\DomainParser\Exception
+ * @namespace Novutec\DomainParser
  */
-namespace Novutec\DomainParser\Exception;
-
-use Novutec\DomainParser\OpenFileException as BaseOpenFileException;
+namespace Novutec\DomainParser;
 
 /**
- * OpenFileException.
+ * AbstractException.
  *
  * @category   Novutec
  *
  * @copyright  Copyright (c) 2007 - 2013 Novutec Inc. (http://www.novutec.com)
  * @license    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * @deprecated
  */
-class OpenFileException extends BaseOpenFileException
+abstract class AbstractException extends \Exception
 {
+    /**
+     * Creates an exception object.
+     *
+     * @param string    $type
+     * @param string    $message
+     * @param int       $code
+     * @param Exception $previous
+     *
+     * @return mixed
+     */
+    public static function factory($type = '', $message = '', $code = 0, Exception $previous = null)
+    {
+        $classname = 'Novutec\DomainParser\Exception\\'.ucfirst($type).'Exception';
+        if (class_exists($classname)) {
+            return new $classname($message, $code, $previous);
+        }
+
+        return new Exception($message, $code, $previous);
+    }
 }

--- a/src/ConnectException.php
+++ b/src/ConnectException.php
@@ -1,12 +1,12 @@
 <?php
 /**
  * Novutec Domain Tools.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,20 +20,20 @@
  */
 
 /**
- * @namespace Novutec\DomainParser\Exception
+ * @namespace Novutec\DomainParser
  */
-namespace Novutec\DomainParser\Exception;
-
-use Novutec\DomainParser\OpenFileException as BaseOpenFileException;
+namespace Novutec\DomainParser;
 
 /**
- * OpenFileException.
+ * ConnectException.
  *
  * @category   Novutec
  *
  * @copyright  Copyright (c) 2007 - 2013 Novutec Inc. (http://www.novutec.com)
  * @license    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * @deprecated use Novutec\DomainParser\Exception\ConnectException instead
  */
-class OpenFileException extends BaseOpenFileException
+class ConnectException extends AbstractException
 {
 }

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -20,7 +20,7 @@
  */
 
 /**
- * @namespace Novutec\DomainParser\Exception
+ * @namespace Novutec\DomainParser
  */
 namespace Novutec\DomainParser;
 
@@ -32,6 +32,6 @@ namespace Novutec\DomainParser;
  * @copyright  Copyright (c) 2007 - 2013 Novutec Inc. (http://www.novutec.com)
  * @license    http://www.apache.org/licenses/LICENSE-2.0
  */
-class Exception extends \Exception
+class Exception extends AbstractException
 {
 }

--- a/src/Exception/ConnectException.php
+++ b/src/Exception/ConnectException.php
@@ -24,7 +24,7 @@
  */
 namespace Novutec\DomainParser\Exception;
 
-use Novutec\DomainParser\Exception;
+use Novutec\DomainParser\ConnectException as BaseConnectException;
 
 /**
  * ConnectException.
@@ -34,6 +34,6 @@ use Novutec\DomainParser\Exception;
  * @copyright  Copyright (c) 2007 - 2013 Novutec Inc. (http://www.novutec.com)
  * @license    http://www.apache.org/licenses/LICENSE-2.0
  */
-class ConnectException extends Exception
+class ConnectException extends BaseConnectException
 {
 }

--- a/src/Exception/UnparsableStringException.php
+++ b/src/Exception/UnparsableStringException.php
@@ -24,7 +24,7 @@
  */
 namespace Novutec\DomainParser\Exception;
 
-use Novutec\DomainParser\Exception;
+use Novutec\DomainParser\UnparsableStringException as BaseUnparsableStringException;
 
 /**
  * UnparsableStringException.
@@ -34,6 +34,6 @@ use Novutec\DomainParser\Exception;
  * @copyright  Copyright (c) 2007 - 2013 Novutec Inc. (http://www.novutec.com)
  * @license    http://www.apache.org/licenses/LICENSE-2.0
  */
-class UnparsableStringException extends Exception
+class UnparsableStringException extends BaseUnparsableStringException
 {
 }

--- a/src/Exception/WriteFileException.php
+++ b/src/Exception/WriteFileException.php
@@ -24,7 +24,7 @@
  */
 namespace Novutec\DomainParser\Exception;
 
-use Novutec\DomainParser\Exception;
+use Novutec\DomainParser\WriteFileException as BaseWriteFileException;
 
 /**
  * WriteFileException.
@@ -34,6 +34,6 @@ use Novutec\DomainParser\Exception;
  * @copyright  Copyright (c) 2007 - 2013 Novutec Inc. (http://www.novutec.com)
  * @license    http://www.apache.org/licenses/LICENSE-2.0
  */
-class WriteFileException extends Exception
+class WriteFileException extends BaseWriteFileException
 {
 }

--- a/src/OpenFileException.php
+++ b/src/OpenFileException.php
@@ -1,12 +1,12 @@
 <?php
 /**
  * Novutec Domain Tools.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,11 +20,9 @@
  */
 
 /**
- * @namespace Novutec\DomainParser\Exception
+ * @namespace Novutec\DomainParser
  */
-namespace Novutec\DomainParser\Exception;
-
-use Novutec\DomainParser\OpenFileException as BaseOpenFileException;
+namespace Novutec\DomainParser;
 
 /**
  * OpenFileException.
@@ -33,7 +31,9 @@ use Novutec\DomainParser\OpenFileException as BaseOpenFileException;
  *
  * @copyright  Copyright (c) 2007 - 2013 Novutec Inc. (http://www.novutec.com)
  * @license    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * @deprecated use Novutec\DomainParser\Exception\OpenFileException instead
  */
-class OpenFileException extends BaseOpenFileException
+class OpenFileException extends AbstractException
 {
 }

--- a/src/UnparsableStringException.php
+++ b/src/UnparsableStringException.php
@@ -1,12 +1,12 @@
 <?php
 /**
  * Novutec Domain Tools.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,20 +20,20 @@
  */
 
 /**
- * @namespace Novutec\DomainParser\Exception
+ * @namespace Novutec\DomainParser
  */
-namespace Novutec\DomainParser\Exception;
-
-use Novutec\DomainParser\OpenFileException as BaseOpenFileException;
+namespace Novutec\DomainParser;
 
 /**
- * OpenFileException.
+ * UnparsableStringException.
  *
  * @category   Novutec
  *
  * @copyright  Copyright (c) 2007 - 2013 Novutec Inc. (http://www.novutec.com)
  * @license    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * @deprecated use Novutec\DomainParser\Exception\UnparsableStringException instead
  */
-class OpenFileException extends BaseOpenFileException
+class UnparsableStringException extends AbstractException
 {
 }

--- a/src/WriteFileException.php
+++ b/src/WriteFileException.php
@@ -1,12 +1,12 @@
 <?php
 /**
  * Novutec Domain Tools.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,20 +20,20 @@
  */
 
 /**
- * @namespace Novutec\DomainParser\Exception
+ * @namespace Novutec\DomainParser
  */
-namespace Novutec\DomainParser\Exception;
-
-use Novutec\DomainParser\OpenFileException as BaseOpenFileException;
+namespace Novutec\DomainParser;
 
 /**
- * OpenFileException.
+ * WriteFileException.
  *
  * @category   Novutec
  *
  * @copyright  Copyright (c) 2007 - 2013 Novutec Inc. (http://www.novutec.com)
  * @license    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * @deprecated use Novutec\DomainParser\Exception\WriteFileException
  */
-class OpenFileException extends BaseOpenFileException
+class WriteFileException extends AbstractException
 {
 }

--- a/tests/AbstractExceptionTest.php
+++ b/tests/AbstractExceptionTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Novutec\DomainParser\Tests;
+
+use Novutec\DomainParser\AbstractException;
+use Novutec\DomainParser\Exception;
+use Novutec\DomainParser\Exception\ConnectException;
+use Novutec\DomainParser\Exception\OpenFileException;
+use Novutec\DomainParser\Exception\UnparsableStringException;
+use Novutec\DomainParser\Exception\WriteFileException;
+use PHPUnit\Framework\TestCase;
+
+class AbstractExceptionTest extends TestCase
+{
+    /**
+     * @dataProvider exceptionTypes
+     *
+     * @param string $type
+     * @param string $expectedExceptionClass
+     */
+    public function testCreateUnparsableStringException($type, $expectedExceptionClass)
+    {
+        $previous = new Exception();
+        $exception = AbstractException::factory($type, 'Exception message.', 42, $previous);
+
+        static::assertInstanceOf($expectedExceptionClass, $exception);
+        static::assertSame('Exception message.', $exception->getMessage());
+        static::assertSame(42, $exception->getCode());
+        static::assertSame($previous, $exception->getPrevious());
+    }
+
+    public function exceptionTypes()
+    {
+        yield 'UnparsableStringException' => ['UnparsableString', UnparsableStringException::class];
+        yield 'OpenFileException' => ['OpenFile', OpenFileException::class];
+        yield 'WriteFileException' => ['WriteFile', WriteFileException::class];
+        yield 'ConnectException' => ['Connect', ConnectException::class];
+    }
+}

--- a/tests/Exception/ConnectExceptionTest.php
+++ b/tests/Exception/ConnectExceptionTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Novutec\DomainParser\Tests\Exception;
+
+use Novutec\DomainParser\ConnectException as LegacyConnectException;
+use Novutec\DomainParser\Exception\ConnectException;
+use PHPUnit\Framework\TestCase;
+
+class ConnectExceptionTest extends TestCase
+{
+    public function testExceptionIsCompatibleWithLegacy()
+    {
+        static::assertInstanceOf(LegacyConnectException::class, new ConnectException());
+    }
+}

--- a/tests/Exception/OpenFileExceptionTest.php
+++ b/tests/Exception/OpenFileExceptionTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Novutec\DomainParser\Tests\Exception;
+
+use Novutec\DomainParser\Exception\OpenFileException;
+use Novutec\DomainParser\OpenFileException as LegacyOpenFileException;
+use PHPUnit\Framework\TestCase;
+
+class OpenFileExceptionTest extends TestCase
+{
+    public function testExceptionIsCompatibleWithLegacy()
+    {
+        static::assertInstanceOf(LegacyOpenFileException::class, new OpenFileException());
+    }
+}

--- a/tests/Exception/UnparsableStringExceptionTest.php
+++ b/tests/Exception/UnparsableStringExceptionTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Novutec\DomainParser\Tests\Exception;
+
+use Novutec\DomainParser\Exception\UnparsableStringException;
+use Novutec\DomainParser\UnparsableStringException as LegacyUnparsableStringException;
+use PHPUnit\Framework\TestCase;
+
+class UnparsableStringExceptionTest extends TestCase
+{
+    public function testExceptionIsCompatibleWithLegacy()
+    {
+        static::assertInstanceOf(LegacyUnparsableStringException::class, new UnparsableStringException());
+    }
+}

--- a/tests/Exception/WriteFileExceptionTest.php
+++ b/tests/Exception/WriteFileExceptionTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Novutec\DomainParser\Tests\Exception;
+
+use Novutec\DomainParser\Exception\WriteFileException;
+use Novutec\DomainParser\Exception\WriteFileException as LegacyWriteFileException;
+use PHPUnit\Framework\TestCase;
+
+class WriteFileExceptionTest extends TestCase
+{
+    public function testExceptionIsCompatibleWithLegacy()
+    {
+        static::assertInstanceOf(LegacyWriteFileException::class, new WriteFileException());
+    }
+}


### PR DESCRIPTION
The PR https://github.com/3name/DomainParser/pull/3 introduce a BC break because of the new exception namespace.

This PR fixes it.
It also introduces phpunit testing (for all maintained PHP versions) and configure Github Actions (results are available here https://github.com/jdecool/DomainParser/actions/runs/1136705065).